### PR TITLE
fix clone method by cloning the jobs also

### DIFF
--- a/internal/entity/job.go
+++ b/internal/entity/job.go
@@ -205,6 +205,31 @@ func (j *Job) TargetResources() CpuResource {
 	return j.targetResources
 }
 
+func (j *Job) Clone() *Job {
+	clone := &Job{
+		workload:          j.workload,
+		currentState:      j.currentState,
+		targetState:       j.targetState,
+		markedForDeletion: j.markedForDeletion,
+		hooks:             j.hooks[:],
+		currentResources:  j.currentResources,
+		targetResources:   j.targetResources,
+	}
+
+	clone.cron = &CronJob{
+		next:     time.UnixMicro(j.cron.next.UnixMicro()),
+		schedule: j.cron.schedule,
+	}
+
+	clone.retry = &RetryJob{
+		next:             time.UnixMicro(j.retry.next.UnixMicro()),
+		MarkedForRestart: j.retry.MarkedForRestart,
+		b:                j.retry.b,
+	}
+
+	return clone
+}
+
 type Builder struct {
 	w            Workload
 	cronSpec     string

--- a/internal/scheduler/store.go
+++ b/internal/scheduler/store.go
@@ -61,9 +61,13 @@ func (s *Store) ToList() []*entity.Job {
 }
 
 func (s *Store) Clone() *Store {
-	return &Store{
-		jobs: s.jobs[:],
+	clone := &Store{
+		jobs: make([]*entity.Job, 0, len(s.jobs)),
 	}
+	for _, j := range s.jobs {
+		clone.jobs = append(clone.jobs, j.Clone())
+	}
+	return clone
 }
 
 func (s *Store) index(id string) (int, error) {


### PR DESCRIPTION
This PR fixes a bug in clone method when the list is cloned but not the elements themselves.
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>